### PR TITLE
Add compatibility verification to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version:
           - 20
+          - 22
           - 24
 
     steps:
@@ -34,5 +36,11 @@ jobs:
       - name: Test
         run: npm test
 
-      - name: Verify package contents
-        run: npm pack --dry-run
+      - name: Verify generated dist is committed
+        run: npm run verify:dist
+
+      - name: Verify package tarball
+        run: npm run verify:pack
+
+      - name: Verify browser bundles
+        run: npm run verify:browser

--- a/package.json
+++ b/package.json
@@ -31,11 +31,15 @@
     "rollup": "^4.61.1"
   },
   "scripts": {
+    "build": "node tools/build",
     "lint": "eslint src test tools",
     "test": "npm run build && node --test test/*.js",
     "test:watch": "node --test --watch test/*.js",
     "test:cover": "npm run build && node --test --experimental-test-coverage test/*.js",
-    "build": "node tools/build",
+    "verify:dist": "npm run build && git diff --exit-code -- dist",
+    "verify:pack": "node tools/verify-pack.js",
+    "verify:browser": "node tools/verify-browser-bundles.js",
+    "verify": "npm run lint && npm test && npm run verify:dist && npm run verify:pack && npm run verify:browser",
     "prepack": "npm run build",
     "publish:docs": "easystatic deploy docs --repo kriasoft/babel-starter-kit",
     "start": "easystatic start docs"

--- a/tools/verify-browser-bundles.js
+++ b/tools/verify-browser-bundles.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const bundles = [
+  'dist/rgb-color.js',
+  'dist/rgb-color.min.js',
+];
+
+for (const bundlePath of bundles) {
+  const code = fs.readFileSync(path.resolve(bundlePath), 'utf8');
+
+  {
+    const sandbox = {};
+
+    vm.runInNewContext(code, sandbox);
+
+    assert.equal(typeof sandbox.rgbcolor, 'function', `${bundlePath} should expose rgbcolor`);
+    assert.equal(sandbox.rgbcolor('#ffffff').hex(), '#ffffff');
+    assert.equal(sandbox.rgbcolor('darkblue').rgb(), 'rgb(0, 0, 139)');
+  }
+
+  {
+    const sandbox = {
+      Number: Object.create(Number, {
+        isNaN: {
+          value: undefined,
+        },
+      }),
+    };
+
+    vm.runInNewContext(code, sandbox);
+
+    assert.equal(
+      sandbox.rgbcolor('#ffffff').hex(),
+      '#ffffff',
+      `${bundlePath} should work without Number.isNaN`,
+    );
+  }
+}
+
+console.log('Browser bundle verification passed.');

--- a/tools/verify-pack.js
+++ b/tools/verify-pack.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+function run(command, args, options = {}) {
+  return execFileSync(command, args, {
+    encoding: 'utf8',
+    stdio: options.stdio || 'pipe',
+    cwd: options.cwd || process.cwd(),
+  });
+}
+
+const repoRoot = process.cwd();
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rgb-color-pack-'));
+
+run('npm', ['run', 'build'], { stdio: 'inherit' });
+
+const packOutput = run('npm', ['pack', '--json']);
+const [packInfo] = JSON.parse(packOutput);
+
+assert.ok(packInfo.filename, 'npm pack should produce a package tarball');
+
+const tarball = path.join(repoRoot, packInfo.filename);
+const consumerDir = path.join(tmpDir, 'consumer');
+
+fs.mkdirSync(consumerDir);
+
+fs.writeFileSync(
+  path.join(consumerDir, 'package.json'),
+  JSON.stringify({ private: true, name: 'rgb-color-consumer' }, null, 2),
+);
+
+run('npm', ['install', tarball], {
+  cwd: consumerDir,
+  stdio: 'inherit',
+});
+
+const smokeTest = `
+const assert = require('node:assert/strict');
+const rgbcolor = require('rgb-color');
+
+assert.equal(typeof rgbcolor, 'function');
+assert.equal(rgbcolor('#ffffff').hex(), '#ffffff');
+assert.equal(rgbcolor('darkblue').rgb(), 'rgb(0, 0, 139)');
+assert.deepEqual(rgbcolor('rgb(900, 300, 257)').channels(), { r: 255, g: 255, b: 255 });
+`;
+
+fs.writeFileSync(path.join(consumerDir, 'smoke-test.cjs'), smokeTest);
+
+run('node', ['smoke-test.cjs'], {
+  cwd: consumerDir,
+  stdio: 'inherit',
+});
+
+const expectedFiles = new Set([
+  'LICENSE.txt',
+  'README.md',
+  'package.json',
+  'dist/LICENSE.txt',
+  'dist/README.md',
+  'dist/package.json',
+  'dist/rgb-color.js',
+  'dist/rgb-color.js.map',
+  'dist/rgb-color.min.js',
+  'dist/rgb-color.min.js.map',
+]);
+
+const actualFiles = new Set(packInfo.files.map(file => file.path));
+
+for (const file of expectedFiles) {
+  assert.ok(actualFiles.has(file), `missing expected package file: ${file}`);
+}
+
+for (const file of actualFiles) {
+  assert.ok(expectedFiles.has(file), `unexpected package file: ${file}`);
+}
+
+fs.rmSync(tarball, { force: true });
+
+console.log('Package verification passed.');


### PR DESCRIPTION
Adds Phase 1 compatibility contract checks before the tooling refresh.

Checks added:
- generated dist files are reproducible and committed
- package tarball installs correctly in a temporary consumer project
- CommonJS require still works from the packed package
- UMD browser bundles expose rgbcolor
- minified UMD bundle exposes rgbcolor
- bundles work without Number.isNaN

This gives us a safety net for future build and packaging modernization.